### PR TITLE
style: improve post list layout and metadata display

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -44,12 +44,12 @@ body::before {
 /* Full-width layout for larger screens */
 @media only screen and (min-width: 992px) {
   .main {
-    width: 50% !important;
+    width: 65% !important;
     max-width: none !important;
   }
 
   .header {
-    width: 50% !important;
+    width: 65% !important;
     max-width: none !important;
   }
 }
@@ -255,15 +255,15 @@ a:hover {
 
 /* Post list item components */
 .postListItem--minimal .postHeader {
-  display: inline-block;
+  display: block;
 }
 
 .postListItem--minimal .postTitle {
   font-size: 1.3rem;
   font-weight: 400;
-  line-height: 1;
+  line-height: 1.2;
   color: #ededed;
-  display: inline;
+  display: block;
   transition: color 0.2s ease;
 }
 
@@ -272,22 +272,24 @@ a:hover {
   cursor: pointer;
 }
 
-.postListItem--minimal .postDate {
-  font-size: 0.8rem;
-  color: #aaa;
-  display: inline;
-  margin-left: 1rem;
-  line-height: 1.5rem;
-  vertical-align: middle;
+.postListItem--minimal .postMeta {
+  color: #a18787;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  display: block;
+  white-space: normal;
+  font-style: italic;
 }
 
-.postListItem--minimal .postTags {
-  font-size: 0.95rem;
-  margin: -0.2rem 0;
-  color: #666;
-  display: block;
-  line-height: 1;
-  font-style: italic;
+.postListItem--minimal .postDate {
+  color: #999;
+  float: none !important;
+}
+
+.postListItem--minimal .postMetaDivider {
+  color: #888;
+  margin: 0rem 0.4rem 0rem 0.2rem;
+  font-weight: 600;
 }
 
 /* POST NAVIGATION AND CONTENT
@@ -433,7 +435,7 @@ strong, b, dt {
 
 /* Heading hierarchy */
 h1 { font-size: 2.5rem; font-weight: 800; line-height: 1.4; }
-h2::before { content: '〉'; } h2 { font-size: 2.3rem; font-weight: 800; line-height: 1.4; letter-spacing: 0.3em !important; margin-top: 3.5rem; margin-bottom: -0.5rem; }
+h2::before { content: '〉'; } h2 { font-size: 2.3rem; font-weight: 800; line-height: 1.4; letter-spacing: 0.05em !important; margin-top: 3.5rem; margin-bottom: -0.5rem; }
 h3::before { content: '》 '; } h3 { font-size: 1.7rem; font-weight: 800; line-height: 1.4;  margin-top: 3rem; margin-bottom: -0.5rem; }
 h4 { font-size: 1.1rem; font-weight: 500; line-height: 1.4; }
 h5 { font-size: 1.0rem; font-weight: 500; line-height: 1.4; }

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -174,3 +174,6 @@
 [back_to_all_series]
   other = "← Back to all series"
 
+[download_pdf]
+  other = "Download PDF"
+

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -173,3 +173,6 @@
 
 [back_to_all_series]
   other = "← すべてのシリーズに戻る"
+
+[download_pdf]
+  other = "PDFをダウンロード"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -53,25 +53,35 @@
             <div class="postListItem{{ if eq .Site.Params.listStyle "minimal" }} postListItem--minimal{{ end }}" role="listitem">
                 <div class="postHeader">
                     <span class="postTitle">{{ .Title }}</span>
-                    {{ if eq .Site.Params.listStyle "minimal" }}
-                        {{ $formattedDateTime := .Date.Format "2006-01-02T15:04:05Z07:00" }}
-                        {{ $dateFormat := i18n "date_format_short" }}
-                        <time class="postDate" datetime="{{ $formattedDateTime }}">{{ .Date.Format $dateFormat }}</time>
-                    {{ else }}
-                        {{ $formattedDate := .Date.Format "2006-01-02" }}
-                        {{ $dateFormat := i18n "date_format_short" }}
-                        <time class="postDate" datetime="{{ $formattedDate }}">{{ .Date.Format $dateFormat }}</time>
-                    {{ end }}
                 </div>
                 {{ if eq .Site.Params.listStyle "minimal" }}
-                    {{ with .GetTerms "tags" }}
-                        <span class="postTags">
-                            {{ range $index, $tag := . }}{{ if $index }}<span style="margin-right: 0.5rem;"></span>{{ end }}#{{ $tag.Name }}{{ end }}
-                        </span>
-                    {{ end }}
+                    <div class="postMeta">
+                        {{ $formattedDateTime := .Date.Format "2006-01-02T15:04:05Z07:00" }}
+                        {{ $dateFormat := i18n "date_format_short" }}
+                        <span class="postMetaDivider">d:</span>
+                        <span class="postMetaText"><time class="postDate" datetime="{{ $formattedDateTime }}">{{ .Date.Format $dateFormat }}</time></span>
+                        {{ with .GetTerms "tags" }}
+                            <span class="postMetaDivider">t:</span>
+                            <span class="postMetaText">
+                                {{ range $index, $tag := . }}{{ if $index }} {{ end }}#{{ $tag.Name }}{{ end }}
+                            </span>
+                        {{ end }}
+                    </div>
                 {{ else }}
                     <div class="postExcerpt">
                         <p>{{ .Summary }}</p>
+                    </div>
+                    <div class="postMeta">
+                        {{ $formattedDate := .Date.Format "2006-01-02" }}
+                        {{ $dateFormat := i18n "date_format_short" }}
+                        <span class="postMetaDivider">d:</span>
+                        <span class="postMetaText"><time class="postDate" datetime="{{ $formattedDate }}">{{ .Date.Format $dateFormat }}</time></span>
+                        {{ with .GetTerms "tags" }}
+                            <span class="postMetaDivider">t:</span>
+                            <span class="postMetaText">
+                                {{ range $index, $tag := . }}{{ if $index }} {{ end }}#{{ $tag.Name }}{{ end }}
+                            </span>
+                        {{ end }}
                     </div>
                 {{ end }}
             </div>


### PR DESCRIPTION
Summary

- Improved post list item layout for better readability
- Enhanced metadata display with clearer visual separation
- Added PDF download translations for multi-language support

Changes

Layout improvements

- Changed main content width from 50% to 65% for better use of screen space
- Updated post list item layout from inline to block display
- Improved line height for post titles (1 → 1.2) for better readability

Metadata display

- Added structured metadata format with dividers (d: for date, t: for tags)
- Improved visual hierarchy with consistent styling
- Changed date color from #aaa to #999 for better contrast
- Added italic style to metadata for visual distinction

Typography

- Reduced h2 letter-spacing from 0.3em to 0.05em for better readability

Internationalization

- Added "Download PDF" translations in English and Japanese